### PR TITLE
Use wind grid for state wind modeling

### DIFF
--- a/pkg/sim/state.go
+++ b/pkg/sim/state.go
@@ -18,6 +18,8 @@ import (
 	"github.com/mmp/vice/pkg/rand"
 	"github.com/mmp/vice/pkg/util"
 
+	"github.com/mmp/vice/pkg/weather"
+
 	"github.com/brunoga/deep"
 )
 
@@ -73,9 +75,8 @@ type State struct {
 	NmPerLongitude    float32
 	PrimaryAirport    string
 
-	METAR      map[string]*av.METAR
-	Wind       av.Wind
-	WindsAloft av.WindProfile
+	METAR    map[string]*av.METAR
+	WindGrid *weather.WindGrid
 
 	TotalIFR, TotalVFR int
 
@@ -136,9 +137,7 @@ func newState(config NewSimConfiguration, manifest *VideoMapManifest, lg *log.Lo
 		NmPerLongitude:    config.NmPerLongitude,
 		PrimaryAirport:    config.PrimaryAirport,
 
-		METAR:      make(map[string]*av.METAR),
-		Wind:       config.Wind,
-		WindsAloft: config.WindsAloft,
+		METAR: make(map[string]*av.METAR),
 
 		SimRate:        1,
 		SimDescription: config.Description,
@@ -149,6 +148,12 @@ func newState(config NewSimConfiguration, manifest *VideoMapManifest, lg *log.Lo
 
 	if manifest != nil {
 		ss.VideoMapLibraryHash, _ = manifest.Hash()
+	}
+
+	if wg, err := weather.LoadWindData(); err == nil {
+		ss.WindGrid = wg
+	} else {
+		lg.Errorf("wind data: %v", err)
 	}
 
 	if len(config.ControllerAirspace) > 0 {
@@ -210,7 +215,7 @@ func newState(config NewSimConfiguration, manifest *VideoMapManifest, lg *log.Lo
 			ss.METAR[ap] = &av.METAR{
 				// Just provide the stuff that the STARS display shows
 				AirportICAO: ap,
-				Wind:        ss.Wind.Randomize(r),
+				Wind:        ss.WindGrid.SurfaceWind().Randomize(r),
 				Altimeter:   fmt.Sprintf("A%d", alt-2+r.Intn(4)),
 			}
 		}
@@ -412,33 +417,23 @@ func (ss *State) GetInitialCenter() math.Point2LL {
 }
 
 func (ss *State) AverageWindVector() [2]float32 {
-	if len(ss.WindsAloft) > 0 {
-		return ss.WindsAloft.AverageWindVector()
+	if ss.WindGrid != nil {
+		return ss.WindGrid.AverageWindVector()
 	}
-
-	d := math.OppositeHeading(float32(ss.Wind.Direction))
-	v := [2]float32{math.Sin(math.Radians(d)), math.Cos(math.Radians(d))}
-	return math.Scale2f(v, float32(ss.Wind.Speed))
+	return [2]float32{}
 }
 func (ss *State) SurfaceWind() av.Wind {
-	if len(ss.WindsAloft) > 0 {
-		return ss.WindsAloft.SurfaceWind()
+	if ss.WindGrid != nil {
+		return ss.WindGrid.SurfaceWind()
 	}
-	return ss.Wind
+	return av.Wind{}
 }
 
 func (ss *State) GetWindVector(p math.Point2LL, alt float32) [2]float32 {
-	if len(ss.WindsAloft) > 0 {
-		return ss.WindsAloft.GetWindVector(p, alt)
+	if ss.WindGrid != nil {
+		return ss.WindGrid.GetWindVector(p, alt)
 	}
-	windSpeed := float32(ss.Wind.Speed)
-
-	// Wind.Direction is where it's coming from, so +180 to get the vector
-	// that affects the aircraft's course.
-	d := math.OppositeHeading(float32(ss.Wind.Direction))
-	vWind := [2]float32{math.Sin(math.Radians(d)), math.Cos(math.Radians(d))}
-	vWind = math.Scale2f(vWind, windSpeed/3600)
-	return vWind
+	return [2]float32{}
 }
 
 func (ss *State) FacilityFromController(callsign string) (string, bool) {

--- a/pkg/weather/windgrid.go
+++ b/pkg/weather/windgrid.go
@@ -1,0 +1,124 @@
+package weather
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	av "github.com/mmp/vice/pkg/aviation"
+	"github.com/mmp/vice/pkg/math"
+)
+
+type WindGrid struct {
+	Points []windPoint `json:"points"`
+}
+
+type windPoint struct {
+	Lat    float64     `json:"lat"`
+	Lon    float64     `json:"lon"`
+	Levels []windLevel `json:"levels"`
+}
+
+type windLevel struct {
+	Mb float64 `json:"mb"`
+	U  float64 `json:"u"`
+	V  float64 `json:"v"`
+	T  float64 `json:"t"`
+	H  float64 `json:"h"`
+}
+
+func LoadWindData() (*WindGrid, error) {
+	path := filepath.Join("vice", "data", "weather", "wind_data.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var wg WindGrid
+	if err := json.Unmarshal(b, &wg); err != nil {
+		return nil, err
+	}
+	return &wg, nil
+}
+
+const mpsToNMPerSec = 1.0 / 1852.0
+const mpsToKnots = 3600.0 / 1852.0
+
+func (wg *WindGrid) nearest(p math.Point2LL) *windPoint {
+	if wg == nil || len(wg.Points) == 0 {
+		return nil
+	}
+	var best *windPoint
+	bestDist := 1e9
+	for i := range wg.Points {
+		dlat := float64(p[1]) - wg.Points[i].Lat
+		dlon := float64(p[0]) - wg.Points[i].Lon
+		dist := dlat*dlat + dlon*dlon
+		if dist < bestDist {
+			bestDist = dist
+			best = &wg.Points[i]
+		}
+	}
+	return best
+}
+
+func windAt(levels []windLevel, altM float64) (float64, float64) {
+	if len(levels) == 0 {
+		return 0, 0
+	}
+	lower, upper := levels[0], levels[len(levels)-1]
+	for i := 1; i < len(levels); i++ {
+		if altM < levels[i].H {
+			upper = levels[i]
+			lower = levels[i-1]
+			break
+		}
+		lower = levels[i]
+	}
+	if upper.H == lower.H {
+		return lower.U, lower.V
+	}
+	f := (altM - lower.H) / (upper.H - lower.H)
+	u := lower.U + (upper.U-lower.U)*f
+	v := lower.V + (upper.V-lower.V)*f
+	return u, v
+}
+
+func (wg *WindGrid) GetWindVector(p math.Point2LL, alt float32) [2]float32 {
+	pt := wg.nearest(p)
+	if pt == nil {
+		return [2]float32{}
+	}
+	u, v := windAt(pt.Levels, float64(alt)*0.3048)
+	return [2]float32{float32(u * mpsToNMPerSec), float32(v * mpsToNMPerSec)}
+}
+
+func (wg *WindGrid) AverageWindVector() [2]float32 {
+	if wg == nil || len(wg.Points) == 0 {
+		return [2]float32{}
+	}
+	var su, sv float64
+	n := 0
+	for _, pt := range wg.Points {
+		if len(pt.Levels) == 0 {
+			continue
+		}
+		lvl := pt.Levels[len(pt.Levels)-1]
+		su += lvl.U
+		sv += lvl.V
+		n++
+	}
+	if n == 0 {
+		return [2]float32{}
+	}
+	return [2]float32{float32(su / float64(n) * mpsToKnots), float32(sv / float64(n) * mpsToKnots)}
+}
+
+func (wg *WindGrid) SurfaceWind() av.Wind {
+	if wg == nil {
+		return av.Wind{}
+	}
+	avv := wg.AverageWindVector()
+	dir := math.NormalizeHeading(math.Degrees(math.Atan2(-avv[0], -avv[1])))
+	spd := int(math.Length2f(avv) + 0.5)
+	return av.Wind{Direction: int(dir + 0.5), Speed: spd}
+}


### PR DESCRIPTION
## Summary
- add `weather` package with `WindGrid` loader
- load global wind grid in state initialization
- provide wind data through `WindGrid` methods
- update METAR generation to use grid data
- remove old fixed/winds aloft references

## Testing
- `go vet ./...` *(fails: C++ source files not allowed when not using cgo)*
- `CGO_ENABLED=1 go build ./...` *(fails: C++ source files not allowed when not using cgo)*
- `go test ./...` *(fails: C++ source files not allowed when not using cgo)*

------
https://chatgpt.com/codex/tasks/task_e_6857780e01e08326b422ad82a3765df1