### PR TITLE
Refactor scenario controller configuration

### DIFF
--- a/aviation/aviation.go
+++ b/aviation/aviation.go
@@ -69,6 +69,9 @@ type Arrival struct {
 	Route           string                              `json:"route"`
 	STAR            string                              `json:"star"`
 
+	EntryFix string `json:"entry_fix"`
+	ExitFix  string `json:"exit_fix"`
+
 	InitialController   string  `json:"initial_controller"`
 	InitialAltitude     float32 `json:"initial_altitude"`
 	AssignedAltitude    float32 `json:"assigned_altitude"`
@@ -907,6 +910,16 @@ func (ar *Arrival) PostDeserialize(loc Locator, nmPerLongitude float32, magnetic
 
 	if ar.InitialSpeed == 0 {
 		e.ErrorString("must specify \"initial_speed\"")
+	}
+
+	ar.EntryFix = strings.ToUpper(strings.TrimSpace(ar.EntryFix))
+	if ar.EntryFix == "" {
+		e.ErrorString("must specify \"entry_fix\"")
+	}
+
+	ar.ExitFix = strings.ToUpper(strings.TrimSpace(ar.ExitFix))
+	if ar.ExitFix == "" {
+		e.ErrorString("must specify \"exit_fix\"")
 	}
 
 	if ar.InitialController == "" {

--- a/aviation/route.go
+++ b/aviation/route.go
@@ -1653,6 +1653,8 @@ type Overflight struct {
 	InitialSpeed        float32                 `json:"initial_speed"`
 	AssignedSpeed       float32                 `json:"assigned_speed"`
 	SpeedRestriction    float32                 `json:"speed_restriction"`
+	EntryFix            string                  `json:"entry_fix"`
+	ExitFix             string                  `json:"exit_fix"`
 	InitialController   string                  `json:"initial_controller"`
 	Scratchpad          string                  `json:"scratchpad"`
 	SecondaryScratchpad string                  `json:"secondary_scratchpad"`
@@ -1710,6 +1712,16 @@ func (of *Overflight) PostDeserialize(loc Locator, nmPerLongitude float32, magne
 
 	if of.InitialSpeed == 0 {
 		e.ErrorString("must specify \"initial_speed\"")
+	}
+
+	of.EntryFix = strings.ToUpper(strings.TrimSpace(of.EntryFix))
+	if of.EntryFix == "" {
+		e.ErrorString("must specify \"entry_fix\"")
+	}
+
+	of.ExitFix = strings.ToUpper(strings.TrimSpace(of.ExitFix))
+	if of.ExitFix == "" {
+		e.ErrorString("must specify \"exit_fix\"")
 	}
 
 	if of.InitialController == "" {

--- a/resources/scenarios/pvd_bones_test.json
+++ b/resources/scenarios/pvd_bones_test.json
@@ -53,6 +53,8 @@
           "initial_altitude": 21000,
           "initial_controller": "ZCB_42",
           "initial_speed": 310,
+          "entry_fix": "ORW",
+          "exit_fix": "PVD",
           "star": "WIPOR3",
           "runway_waypoints": {
             "KPVD": {
@@ -123,14 +125,22 @@
           "KPVD": 10
         }
       },
-      "solo_controller": "NCA_1D",
-      "multi_controllers": {
-        "default": {
-          "1D": { "primary": true, "arrivals": ["WIPOR"] },
-          "1A": { "backup": "1D", "departures": ["KPVD"], "arrivals": [] }
+      "solo_configuration": {
+        "configuration_id": "FG2",
+        "solo_position": {
+          "PVD_1D": { "consolidated_tcps": ["PVD_1A"] }
         }
       },
-      "controllers": ["NCA_1A", "ZCB_42"],
+      "multi_configuration": {
+        "configuration_id": "FG2",
+        "positions": {
+          "PVD_1D": { "consolidated_positions": [] },
+          "PVD_1A": { "consolidated_positions": [] }
+        }
+      },
+      "virtual_positions": {
+        "ZBW_42": { "consolidated_positions": [] }
+      },
       "default_maps": ["RVMPVD011S"],
       "departure_runways": [
         {
@@ -193,7 +203,7 @@
       "JUMPR": "7TN"
     },
     "coordination_lists": [
-      { "name": ".     PVD D DEP", "id": "D", "airports": ["KPVD"] }
+      { "name": ".     PVD D DEP", "id": "D", "positions": ["PVD_1D"] }
     ],
     "significant_points": {
       "PUT": {},

--- a/server/manager.go
+++ b/server/manager.go
@@ -83,12 +83,17 @@ type connectionState struct {
 }
 
 type SimScenarioConfiguration struct {
-	SelectedController  string
-	SelectedSplit       string
-	SplitConfigurations av.SplitConfigurationSet
-	PrimaryAirport      string
-	MagneticVariation   float32
-	WindSpecifier       *wx.WindSpecifier
+	SelectedController    string
+	SelectedSplit         string
+	SplitConfigurations   av.SplitConfigurationSet
+	SoloController        string
+	SoloControllerConfig  *sim.ControllerConfiguration
+	MultiControllerConfig *sim.ControllerConfiguration
+	VirtualPositionConfig map[string]sim.ControllerPositionConfig
+	FixPairAssignments    map[string]map[sim.FixPairKey]string
+	PrimaryAirport        string
+	MagneticVariation     float32
+	WindSpecifier         *wx.WindSpecifier
 
 	LaunchConfig sim.LaunchConfig
 
@@ -463,6 +468,10 @@ func (sm *SimManager) makeSimConfiguration(config *NewSimConfiguration, lg *log.
 		ControllerAirspace:          sc.Airspace,
 		ControlPositions:            sg.ControlPositions,
 		VirtualControllers:          sc.VirtualControllers,
+		SoloControllerConfig:        sc.SoloControllerConfig,
+		MultiControllerConfig:       sc.MultiControllerConfig,
+		VirtualPositionConfig:       sc.VirtualPositionConfig,
+		FixPairAssignments:          sc.FixPairAssignments,
 		SignOnPositions:             make(map[string]*av.Controller),
 		TTSProvider:                 sm.tts,
 		WXProvider:                  sm.wxProvider,

--- a/server/scenario.go
+++ b/server/scenario.go
@@ -55,11 +55,38 @@ type scenarioGroup struct {
 	FacilityAdaptation sim.FacilityAdaptation `json:"stars_config"`
 }
 
+type scenarioSoloPosition struct {
+	ConsolidatedTCPs []string `json:"consolidated_tcps"`
+}
+
+type scenarioSoloConfiguration struct {
+	ConfigurationID string                           `json:"configuration_id"`
+	SoloPosition    map[string]*scenarioSoloPosition `json:"solo_position"`
+}
+
+type scenarioPositionSpec struct {
+	ConsolidatedPositions []string `json:"consolidated_positions"`
+}
+
+type scenarioMultiConfiguration struct {
+	ConfigurationID string                           `json:"configuration_id"`
+	Positions       map[string]*scenarioPositionSpec `json:"positions"`
+}
+
 type scenario struct {
-	SoloController      string                   `json:"solo_controller"`
-	SplitConfigurations av.SplitConfigurationSet `json:"multi_controllers"`
-	DefaultSplit        string                   `json:"default_split"`
-	VirtualControllers  []string                 `json:"controllers"`
+	SoloConfiguration    *scenarioSoloConfiguration       `json:"solo_configuration"`
+	MultiConfiguration   *scenarioMultiConfiguration      `json:"multi_configuration"`
+	VirtualPositionSpecs map[string]*scenarioPositionSpec `json:"virtual_positions"`
+
+	SoloController      string                   `json:"-"`
+	SplitConfigurations av.SplitConfigurationSet `json:"-"`
+	DefaultSplit        string                   `json:"-"`
+	VirtualControllers  []string                 `json:"-"`
+
+	SoloControllerConfig  *sim.ControllerConfiguration            `json:"-"`
+	MultiControllerConfig *sim.ControllerConfiguration            `json:"-"`
+	VirtualPositionConfig map[string]sim.ControllerPositionConfig `json:"-"`
+	FixPairAssignments    map[string]map[sim.FixPairKey]string    `json:"-"`
 
 	WindSpecifier *wx.WindSpecifier `json:"wind,omitempty"`
 
@@ -80,6 +107,294 @@ type scenario struct {
 	DefaultMaps     []string      `json:"default_maps"`
 	DefaultMapGroup string        `json:"default_map_group" scope:"eram"`
 	VFRRateScale    *float32      `json:"vfr_rate_scale"`
+}
+
+func sanitizePositionList(values []string) []string {
+	seen := make(map[string]struct{})
+	var result []string
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		result = append(result, v)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func (sg *scenarioGroup) resolveControllerByFacility(facilityID, identifier string) (string, bool) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return "", false
+	}
+
+	// Direct lookups first.
+	if ctrl, ok := sg.ControlPositions[identifier]; ok && ctrl != nil {
+		if facilityID == "" || strings.EqualFold(ctrl.Facility, facilityID) {
+			return ctrl.Position, true
+		}
+	}
+
+	upper := strings.ToUpper(identifier)
+	if ctrl, ok := sg.ControlPositions[upper]; ok && ctrl != nil {
+		if facilityID == "" || strings.EqualFold(ctrl.Facility, facilityID) {
+			return ctrl.Position, true
+		}
+	}
+
+	// Try to match by facility-qualified identifier
+	routingOnly := ""
+	if fac, routing, ok := strings.Cut(upper, "_"); ok && routing != "" {
+		routingOnly = routing
+		if strings.EqualFold(fac, facilityID) {
+			if ctrl, ok := sg.ControlPositions[fac+"_"+routing]; ok && ctrl != nil {
+				return ctrl.Position, true
+			}
+		}
+	}
+
+	for _, ctrl := range sg.ControlPositions {
+		if ctrl == nil {
+			continue
+		}
+		if facilityID != "" && !strings.EqualFold(ctrl.Facility, facilityID) {
+			continue
+		}
+		if strings.EqualFold(ctrl.Position, identifier) || strings.EqualFold(ctrl.FacilityPositionID(), identifier) ||
+			strings.EqualFold(ctrl.Id(), identifier) {
+			return ctrl.Position, true
+		}
+		if strings.EqualFold(ctrl.SectorRoutingID(), upper) || strings.EqualFold(ctrl.TCP, upper) ||
+			(routingOnly != "" && strings.EqualFold(ctrl.SectorRoutingID(), routingOnly)) {
+			return ctrl.Position, true
+		}
+	}
+
+	return "", false
+}
+
+func (s *scenario) initializeControllerConfigurations(sg *scenarioGroup, e *util.ErrorLogger) {
+	if s.SoloConfiguration == nil {
+		e.ErrorString("must specify \"solo_configuration\"")
+		return
+	}
+
+	s.SoloControllerConfig = &sim.ControllerConfiguration{
+		Positions: make(map[string]sim.ControllerPositionConfig),
+	}
+
+	s.SoloConfiguration.ConfigurationID = strings.ToUpper(strings.TrimSpace(s.SoloConfiguration.ConfigurationID))
+	if s.SoloConfiguration.ConfigurationID == "" {
+		e.ErrorString("\"solo_configuration.configuration_id\" must be specified")
+	}
+	s.SoloControllerConfig.ConfigurationID = s.SoloConfiguration.ConfigurationID
+
+	if len(s.SoloConfiguration.SoloPosition) != 1 {
+		e.ErrorString("\"solo_configuration.solo_position\" must specify exactly one controller")
+	}
+
+	for ctrl, spec := range s.SoloConfiguration.SoloPosition {
+		ctrl = strings.TrimSpace(ctrl)
+		if ctrl == "" {
+			e.ErrorString("\"solo_configuration.solo_position\" must not contain empty controller identifiers")
+			continue
+		}
+		if spec == nil {
+			e.ErrorString("definition for solo controller %q is missing", ctrl)
+			continue
+		}
+
+		s.SoloController = ctrl
+
+		consolidated := sanitizePositionList(spec.ConsolidatedTCPs)
+		s.SoloControllerConfig.Positions[ctrl] = sim.ControllerPositionConfig{ConsolidatedPositions: consolidated}
+
+		if _, ok := sg.ControlPositions[ctrl]; !ok {
+			e.ErrorString("controller %q for \"solo_configuration\" is unknown", ctrl)
+		}
+		for _, c := range consolidated {
+			if _, ok := sg.ControlPositions[c]; !ok {
+				e.ErrorString("consolidated controller %q for solo controller %q is unknown", c, ctrl)
+			}
+		}
+	}
+
+	if s.MultiConfiguration != nil {
+		s.MultiConfiguration.ConfigurationID = strings.ToUpper(strings.TrimSpace(s.MultiConfiguration.ConfigurationID))
+		if s.MultiConfiguration.ConfigurationID == "" {
+			e.ErrorString("\"multi_configuration.configuration_id\" must be specified")
+		}
+		if s.SoloControllerConfig.ConfigurationID != "" && s.MultiConfiguration.ConfigurationID != "" &&
+			!strings.EqualFold(s.SoloControllerConfig.ConfigurationID, s.MultiConfiguration.ConfigurationID) {
+			e.ErrorString("\"multi_configuration.configuration_id\" must match \"solo_configuration.configuration_id\"")
+		}
+
+		positions := make(map[string]sim.ControllerPositionConfig)
+		var keys []string
+		for ctrl, spec := range s.MultiConfiguration.Positions {
+			ctrl = strings.TrimSpace(ctrl)
+			if ctrl == "" {
+				e.ErrorString("\"multi_configuration.positions\" must not contain empty controller identifiers")
+				continue
+			}
+			if spec == nil {
+				e.ErrorString("definition for multi controller %q is missing", ctrl)
+				continue
+			}
+
+			consolidated := sanitizePositionList(spec.ConsolidatedPositions)
+			positions[ctrl] = sim.ControllerPositionConfig{ConsolidatedPositions: consolidated}
+			keys = append(keys, ctrl)
+
+			if _, ok := sg.ControlPositions[ctrl]; !ok {
+				e.ErrorString("controller %q in \"multi_configuration\" is unknown", ctrl)
+			}
+			for _, c := range consolidated {
+				if _, ok := sg.ControlPositions[c]; !ok {
+					e.ErrorString("consolidated controller %q for controller %q is unknown", c, ctrl)
+				}
+			}
+		}
+
+		if len(positions) == 0 {
+			e.ErrorString("\"multi_configuration.positions\" must specify at least one controller")
+		}
+
+		s.MultiControllerConfig = &sim.ControllerConfiguration{
+			ConfigurationID: s.MultiConfiguration.ConfigurationID,
+			Positions:       positions,
+		}
+
+		slices.Sort(keys)
+		cfg := make(av.SplitConfiguration)
+		for i, ctrl := range keys {
+			cfg[ctrl] = &av.MultiUserController{Primary: i == 0}
+		}
+		s.SplitConfigurations = av.SplitConfigurationSet{s.MultiConfiguration.ConfigurationID: cfg}
+		s.DefaultSplit = s.MultiConfiguration.ConfigurationID
+	} else {
+		s.MultiControllerConfig = nil
+		s.SplitConfigurations = av.SplitConfigurationSet{
+			"default": {
+				s.SoloController: &av.MultiUserController{Primary: true},
+			},
+		}
+		s.DefaultSplit = "default"
+	}
+
+	s.VirtualPositionConfig = make(map[string]sim.ControllerPositionConfig)
+	if len(s.VirtualPositionSpecs) > 0 {
+		var vkeys []string
+		for ctrl, spec := range s.VirtualPositionSpecs {
+			ctrl = strings.TrimSpace(ctrl)
+			if ctrl == "" {
+				e.ErrorString("\"virtual_positions\" must not contain empty controller identifiers")
+				continue
+			}
+			if spec == nil {
+				e.ErrorString("definition for virtual controller %q is missing", ctrl)
+				continue
+			}
+
+			consolidated := sanitizePositionList(spec.ConsolidatedPositions)
+			s.VirtualPositionConfig[ctrl] = sim.ControllerPositionConfig{ConsolidatedPositions: consolidated}
+			vkeys = append(vkeys, ctrl)
+
+			if _, ok := sg.ControlPositions[ctrl]; !ok {
+				e.ErrorString("virtual controller %q is unknown", ctrl)
+			}
+			for _, c := range consolidated {
+				if _, ok := sg.ControlPositions[c]; !ok {
+					e.ErrorString("virtual consolidated controller %q for %q is unknown", c, ctrl)
+				}
+			}
+		}
+		slices.Sort(vkeys)
+		s.VirtualControllers = vkeys
+	} else {
+		s.VirtualControllers = nil
+	}
+}
+
+func (s *scenario) initializeFixPairAssignments(sg *scenarioGroup, e *util.ErrorLogger) {
+	s.FixPairAssignments = make(map[string]map[sim.FixPairKey]string)
+
+	var facilityID string
+	if ctrl, ok := sg.ControlPositions[s.SoloController]; ok && ctrl != nil {
+		facilityID = ctrl.Facility
+	}
+
+	if facilityID == "" {
+		e.ErrorString("unable to determine facility for solo controller %q", s.SoloController)
+		return
+	}
+
+	facilityConfig := sg.FacilityAdaptation.TCPConfiguration.FixPairConfiguration[facilityID]
+	if facilityConfig == nil {
+		e.ErrorString("no \"fix_pair_configuration\" defined for facility %q", facilityID)
+		return
+	}
+
+	ensureConfigMap := func(id string) {
+		if id == "" {
+			return
+		}
+		id = strings.ToUpper(id)
+		if _, ok := s.FixPairAssignments[id]; !ok {
+			s.FixPairAssignments[id] = make(map[sim.FixPairKey]string)
+		}
+	}
+
+	ensureConfigMap(s.SoloControllerConfig.ConfigurationID)
+	if s.MultiControllerConfig != nil {
+		ensureConfigMap(s.MultiControllerConfig.ConfigurationID)
+	}
+
+	relevantConfig := func(id string) bool {
+		if id == "" {
+			return false
+		}
+		id = strings.ToUpper(id)
+		if s.SoloControllerConfig != nil && strings.EqualFold(id, s.SoloControllerConfig.ConfigurationID) {
+			return true
+		}
+		if s.MultiControllerConfig != nil && strings.EqualFold(id, s.MultiControllerConfig.ConfigurationID) {
+			return true
+		}
+		return false
+	}
+
+	for _, assignment := range facilityConfig.FixPairTCPAssignments {
+		owner, ok := sg.resolveControllerByFacility(facilityID, assignment.TCP)
+		if !ok {
+			e.ErrorString("tcp %q in \"fix_pair_tcp_assignments\" is unknown for facility %q", assignment.TCP, facilityID)
+			continue
+		}
+
+		flightType := strings.ToUpper(strings.TrimSpace(assignment.FlightType))
+		entryFix := strings.ToUpper(strings.TrimSpace(assignment.EntryFix))
+		exitFix := strings.ToUpper(strings.TrimSpace(assignment.ExitFix))
+
+		if flightType == "" || entryFix == "" || exitFix == "" {
+			continue
+		}
+
+		key := sim.FixPairKey{FlightType: flightType, EntryFix: entryFix, ExitFix: exitFix}
+
+		for _, cfg := range assignment.Configuration {
+			if !relevantConfig(cfg) {
+				continue
+			}
+			cfg = strings.ToUpper(cfg)
+			ensureConfigMap(cfg)
+			s.FixPairAssignments[cfg][key] = owner
+		}
+	}
 }
 
 func (s *scenario) PostDeserialize(sg *scenarioGroup, e *util.ErrorLogger, manifest *sim.VideoMapManifest) {
@@ -103,65 +418,17 @@ func (s *scenario) PostDeserialize(sg *scenarioGroup, e *util.ErrorLogger, manif
 			s.ArrivalGroupDefaultRates = nil
 		}
 	}
+	s.initializeControllerConfigurations(sg, e)
+	s.initializeFixPairAssignments(sg, e)
+
 	for name, controllers := range s.SplitConfigurations {
 		e.Push("\"multi_controllers\": split \"" + name + "\"")
-		for _, ctrl := range controllers {
-			if len(ctrl.Arrivals) > 0 {
-				if len(ctrl.InboundFlows) > 0 {
-					e.ErrorString("cannot specify both \"arrivals\" and \"inbound_flows\"")
-				} else {
-					ctrl.InboundFlows = ctrl.Arrivals
-					ctrl.Arrivals = nil
-				}
+		for callsign := range controllers {
+			if _, ok := sg.ControlPositions[callsign]; !ok {
+				e.ErrorString("controller %q not defined in the scenario group's \"control_positions\"", callsign)
 			}
 		}
 		e.Pop()
-	}
-
-	// Auto-populate SplitConfigurations for single-controller scenarios
-	if s.SoloController != "" && len(s.SplitConfigurations) == 0 {
-		// Collect departure airports that don't have virtual controllers
-		// (airports with virtual controllers are handled by those
-		// controllers, not the human).
-		departures := make(map[string]bool)
-		for _, rwy := range s.DepartureRunways {
-			if ap, ok := sg.Airports[rwy.Airport]; ok && ap.DepartureController == "" {
-				departures[rwy.Airport] = true
-			}
-		}
-		departureList := slices.Collect(maps.Keys(departures))
-
-		// Collect inbound flows that have handoffs to human controllers.
-		var inboundFlows []string
-		for flowName := range s.InboundFlowDefaultRates {
-			if flow, ok := sg.InboundFlows[flowName]; ok {
-				// Check if this flow has arrivals or overflights with handoffs
-				hasHandoff := len(flow.Arrivals) > 0
-				if !hasHandoff {
-					// Check if any overflight has a human handoff
-					hasHandoff = slices.ContainsFunc(flow.Overflights, func(of av.Overflight) bool {
-						return slices.ContainsFunc(of.Waypoints, func(wp av.Waypoint) bool {
-							return wp.HumanHandoff
-						})
-					})
-				}
-				if hasHandoff {
-					inboundFlows = append(inboundFlows, flowName)
-				}
-			}
-		}
-
-		// Create the default split configuration
-		s.SplitConfigurations = av.SplitConfigurationSet{
-			"default": av.SplitConfiguration{
-				s.SoloController: &av.MultiUserController{
-					Primary:      true,
-					Departures:   departureList,
-					InboundFlows: inboundFlows,
-				},
-			},
-		}
-		s.DefaultSplit = "default"
 	}
 
 	for ctrl, vnames := range s.Airspace {
@@ -277,7 +544,7 @@ func (s *scenario) PostDeserialize(sg *scenarioGroup, e *util.ErrorLogger, manif
 	}
 
 	if _, ok := sg.ControlPositions[s.SoloController]; s.SoloController != "" && !ok {
-		e.ErrorString("controller %q for \"solo_controller\" is unknown", s.SoloController)
+		e.ErrorString("controller %q for \"solo_configuration\" is unknown", s.SoloController)
 	}
 
 	// Figure out which airports/runways and airports/SIDs are used in the scenario.
@@ -1289,6 +1556,12 @@ func (sg *scenarioGroup) rewriteControllers(e *util.ErrorLogger) {
 		fa.ControllerConfigs[position] = config
 	}
 
+	for i := range fa.CoordinationLists {
+		for j := range fa.CoordinationLists[i].Positions {
+			rewrite(&fa.CoordinationLists[i].Positions[j])
+		}
+	}
+
 	for _, flow := range sg.InboundFlows {
 		for i := range flow.Arrivals {
 			rewrite(&flow.Arrivals[i].InitialController)
@@ -1518,27 +1791,6 @@ func PostDeserializeFacilityAdaptation(s *sim.FacilityAdaptation, e *util.ErrorL
 		}
 	}
 
-	// Hold for release validation
-	for airport, ap := range sg.Airports {
-		var matches []string
-		for _, list := range s.CoordinationLists {
-			if slices.Contains(list.Airports, airport) {
-				matches = append(matches, list.Name)
-			}
-		}
-
-		if ap.HoldForRelease {
-			// Make sure it's in either zero or one of the coordination lists.
-			if len(matches) > 1 {
-				e.ErrorString("Airport %q is in multiple entries in \"coordination_lists\": %s.", airport, strings.Join(matches, ", "))
-			}
-		} else if len(matches) != 0 {
-			// And it shouldn't be any if it's not hold for release
-			e.ErrorString("Airport %q isn't \"hold_for_release\" but is in \"coordination_lists\": %s.", airport,
-				strings.Join(matches, ", "))
-		}
-	}
-
 	if s.MonitoredBeaconCodeBlocksString == nil {
 		s.MonitoredBeaconCodeBlocks = []av.Squawk{0o12} // 12xx block by default
 	} else {
@@ -1593,16 +1845,16 @@ func PostDeserializeFacilityAdaptation(s *sim.FacilityAdaptation, e *util.ErrorL
 		if list.Id == "" {
 			e.ErrorString("\"id\" must be specified for coordination list.")
 		}
-		if len(list.Airports) == 0 {
-			e.ErrorString("At least one airport must be specified in \"airports\" for coordination list.")
+		if len(list.Positions) == 0 {
+			e.ErrorString("At least one controller must be specified in \"positions\" for coordination list.")
 		}
 
 		seenIds[list.Id] = append(seenIds[list.Id], list.Name)
 
-		// Make sure all airport names in coordination lists are part of the scenario.
-		for _, ap := range list.Airports {
-			if _, ok := sg.Airports[ap]; !ok {
-				e.ErrorString("Airport %q not defined in scenario group.", ap)
+		// Make sure all positions in coordination lists are part of the scenario.
+		for _, pos := range list.Positions {
+			if _, ok := sg.ControlPositions[pos]; !ok {
+				e.ErrorString("Control position %q not defined in scenario group.", pos)
 			}
 		}
 
@@ -1757,13 +2009,18 @@ func initializeSimConfigurations(sg *scenarioGroup, simConfigurations map[string
 		lc := sim.MakeLaunchConfig(scenario.DepartureRunways, *scenario.VFRRateScale, vfrAirports,
 			scenario.InboundFlowDefaultRates, haveVFRReportingRegions)
 		sc := &SimScenarioConfiguration{
-			SplitConfigurations: scenario.SplitConfigurations,
-			LaunchConfig:        lc,
-			DepartureRunways:    scenario.DepartureRunways,
-			ArrivalRunways:      scenario.ArrivalRunways,
-			PrimaryAirport:      sg.PrimaryAirport,
-			MagneticVariation:   sg.MagneticVariation,
-			WindSpecifier:       scenario.WindSpecifier,
+			SplitConfigurations:   scenario.SplitConfigurations,
+			SoloController:        scenario.SoloController,
+			SoloControllerConfig:  scenario.SoloControllerConfig,
+			MultiControllerConfig: scenario.MultiControllerConfig,
+			VirtualPositionConfig: scenario.VirtualPositionConfig,
+			FixPairAssignments:    scenario.FixPairAssignments,
+			LaunchConfig:          lc,
+			DepartureRunways:      scenario.DepartureRunways,
+			ArrivalRunways:        scenario.ArrivalRunways,
+			PrimaryAirport:        sg.PrimaryAirport,
+			MagneticVariation:     sg.MagneticVariation,
+			WindSpecifier:         scenario.WindSpecifier,
 		}
 
 		// All scenarios now have SplitConfigurations (auto-populated if

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -169,6 +169,28 @@ type ArrivalRunway struct {
 	Runway  string `json:"runway"`
 }
 
+// FixPairKey uniquely identifies a fix-pair assignment used to determine
+// initial controller ownership for a flight based on its entry and exit fixes
+// as well as its flight type.
+type FixPairKey struct {
+	FlightType string
+	EntryFix   string
+	ExitFix    string
+}
+
+// ControllerPositionConfig describes how a controller position consolidates
+// other positions within a scenario configuration.
+type ControllerPositionConfig struct {
+	ConsolidatedPositions []string
+}
+
+// ControllerConfiguration captures the consolidation rules that apply for a
+// particular sector configuration within a scenario.
+type ControllerConfiguration struct {
+	ConfigurationID string
+	Positions       map[string]ControllerPositionConfig
+}
+
 type Handoff struct {
 	AutoAcceptTime    time.Time
 	ReceivingFacility string // only for auto accept
@@ -207,6 +229,11 @@ type NewSimConfiguration struct {
 	VirtualControllers []string
 	MultiControllers   av.SplitConfiguration
 	SignOnPositions    map[string]*av.Controller
+
+	SoloControllerConfig  *ControllerConfiguration
+	MultiControllerConfig *ControllerConfiguration
+	VirtualPositionConfig map[string]ControllerPositionConfig
+	FixPairAssignments    map[string]map[FixPairKey]string
 
 	TFRs               []av.TFR
 	FacilityAdaptation FacilityAdaptation

--- a/sim/spawn.go
+++ b/sim/spawn.go
@@ -1138,17 +1138,20 @@ func (s *Sim) createArrivalNoLock(group string, arrivalAirport string) (*Aircraf
 		}
 	}
 
+	entryFix := arr.EntryFix
+	exitFix := arr.ExitFix
+
 	starsFp := NASFlightPlan{
 		ACID:             ACID(ac.ADSBCallsign),
-		EntryFix:         "", // TODO
-		ExitFix:          util.Select(len(ac.FlightPlan.ArrivalAirport) == 4, ac.FlightPlan.ArrivalAirport[1:], ac.FlightPlan.ArrivalAirport),
+		EntryFix:         entryFix,
+		ExitFix:          exitFix,
 		ArrivalAirport:   ac.FlightPlan.ArrivalAirport,
 		CoordinationTime: getAircraftTime(s.State.SimTime, s.Rand),
 		PlanType:         RemoteEnroute,
 
 		TrackingController:       arr.InitialController,
 		ControllingController:    arr.InitialController,
-		InboundHandoffController: s.getInboundHandoffController(arr.InitialController, group, ac.Nav.Waypoints),
+		InboundHandoffController: s.getInboundHandoffController(arr.InitialController, "A", entryFix, exitFix, ac.Nav.Waypoints),
 
 		Rules:        av.FlightRulesIFR,
 		TypeOfFlight: av.FlightTypeArrival,
@@ -1187,7 +1190,7 @@ func (s *Sim) createArrivalNoLock(group string, arrivalAirport string) (*Aircraf
 	return ac, err
 }
 
-func (s *Sim) getInboundHandoffController(initialTCP string, group string, wps av.WaypointArray) string {
+func (s *Sim) getInboundHandoffController(initialTCP string, flightType string, entryFix string, exitFix string, wps av.WaypointArray) string {
 	if tcp := s.State.ResolveController(initialTCP); initialTCP != "" && s.isActiveHumanController(tcp) {
 		return initialTCP
 	} else if slices.ContainsFunc(wps, func(wp av.Waypoint) bool { return wp.HumanHandoff }) {
@@ -1197,19 +1200,9 @@ func (s *Sim) getInboundHandoffController(initialTCP string, group string, wps a
 		// the actual handoff controller will be resolved later when the
 		// handoff happens, so that it can reflect which controllers are
 		// actually signed in at that point.
-		hoTCP := s.State.PrimaryController
-		if len(s.State.MultiControllers) > 0 {
-			var err error
-			hoTCP, err = s.State.MultiControllers.GetInboundController(group)
-			if err != nil {
-				s.lg.Error("Unable to resolve arrival controller", slog.Any("error", err),
-					slog.String("initialTCP", initialTCP), slog.String("group", group),
-					slog.Any("waypoints", wps))
-			}
-
-			if hoTCP == "" {
-				hoTCP = s.State.PrimaryController
-			}
+		hoTCP := s.State.ResolveFixPairOwner(flightType, entryFix, exitFix)
+		if hoTCP == "" {
+			hoTCP = s.State.PrimaryController
 		}
 		return hoTCP
 	}
@@ -1311,11 +1304,21 @@ func (s *Sim) createIFRDepartureNoLock(departureAirport, runway, category string
 	}
 
 	shortExit, _, _ := strings.Cut(dep.Exit, ".") // chop any excess
+	entryFix := strings.ToUpper(departureAirport)
+	if len(entryFix) == 4 && entryFix[0] == 'K' {
+		entryFix = entryFix[1:]
+	}
+	exitFix := strings.ToUpper(shortExit)
+	fixPairOwner := s.State.ResolveFixPairOwner("P", entryFix, exitFix)
+	if fixPairOwner == "" {
+		fixPairOwner = s.State.PrimaryController
+	}
+
 	_, tracon := av.DB.TRACONs[s.State.TRACON]
 	starsFp := NASFlightPlan{
 		ACID:             ACID(ac.ADSBCallsign),
-		EntryFix:         util.Select(len(ac.FlightPlan.DepartureAirport) == 4, ac.FlightPlan.DepartureAirport[1:], ac.FlightPlan.DepartureAirport),
-		ExitFix:          shortExit,
+		EntryFix:         entryFix,
+		ExitFix:          exitFix,
 		ArrivalAirport:   ac.FlightPlan.ArrivalAirport,
 		CoordinationTime: getAircraftTime(s.State.SimTime, s.Rand),
 		PlanType:         RemoteEnroute,
@@ -1338,22 +1341,10 @@ func (s *Sim) createIFRDepartureNoLock(departureAirport, runway, category string
 		// starting out with a virtual controller
 		starsFp.TrackingController = ap.DepartureController
 		starsFp.ControllingController = ap.DepartureController
-		starsFp.InboundHandoffController = exitRoute.HandoffController
+		starsFp.InboundHandoffController = fixPairOwner
 	} else {
 		// human controller will be first
-		ctrl := s.State.PrimaryController
-		if len(s.State.MultiControllers) > 0 {
-			var err error
-			ctrl, err = s.State.MultiControllers.GetDepartureController(departureAirport, runway, exitRoute.SID)
-			if err != nil {
-				s.lg.Error("unable to get departure controller", slog.Any("error", err),
-					slog.String("adsb_callsign", string(ac.ADSBCallsign)), slog.Any("aircraft", ac))
-			}
-		}
-		if ctrl == "" {
-			ctrl = s.State.PrimaryController
-		}
-
+		ctrl := fixPairOwner
 		ac.DepartureContactAltitude =
 			ac.Nav.FlightState.DepartureAirportElevation + 500 + float32(s.Rand.Intn(500))
 		ac.DepartureContactAltitude = min(ac.DepartureContactAltitude, float32(ac.FlightPlan.Altitude))
@@ -1404,15 +1395,15 @@ func (s *Sim) createOverflightNoLock(group string) (*Aircraft, error) {
 	_, tracon := av.DB.TRACONs[s.State.TRACON]
 	starsFp := NASFlightPlan{
 		ACID:             ACID(ac.ADSBCallsign),
-		EntryFix:         "", // TODO
-		ExitFix:          "", // TODO
+		EntryFix:         of.EntryFix,
+		ExitFix:          of.ExitFix,
 		ArrivalAirport:   ac.FlightPlan.ArrivalAirport,
 		CoordinationTime: getAircraftTime(s.State.SimTime, s.Rand),
 		PlanType:         RemoteEnroute,
 
 		TrackingController:       of.InitialController,
 		ControllingController:    of.InitialController,
-		InboundHandoffController: s.getInboundHandoffController(of.InitialController, group, ac.Nav.Waypoints),
+		InboundHandoffController: s.getInboundHandoffController(of.InitialController, "E", of.EntryFix, of.ExitFix, ac.Nav.Waypoints),
 
 		Rules:               av.FlightRulesIFR,
 		TypeOfFlight:        av.FlightTypeOverflight,

--- a/sim/stars.go
+++ b/sim/stars.go
@@ -431,11 +431,11 @@ type STARSControllerConfig struct {
 }
 
 type CoordinationList struct {
-	Name          string   `json:"name"`
-	Id            string   `json:"id"`
-	Airports      []string `json:"airports"`
-	YellowEntries bool     `json:"yellow_entries"`
-	Format        string   `json:"format"`
+        Name          string   `json:"name"`
+        Id            string   `json:"id"`
+        Positions     []string `json:"positions"`
+        YellowEntries bool     `json:"yellow_entries"`
+        Format        string   `json:"format"`
 }
 
 type STARSFacilityTCPConfiguration struct {

--- a/sim/state.go
+++ b/sim/state.go
@@ -48,6 +48,18 @@ type State struct {
 	Controllers      map[string]*av.Controller
 	HumanControllers []string
 
+	ControlPositions map[string]*av.Controller
+
+	SoloControllerConfig  *ControllerConfiguration
+	MultiControllerConfig *ControllerConfiguration
+	VirtualPositionConfig map[string]ControllerPositionConfig
+	FixPairAssignments    map[string]map[FixPairKey]string
+
+	activeControllerConfig *ControllerConfiguration
+	consolidationLookup    map[string]string
+	virtualConsolidation   map[string]string
+	activeConfigurationID  string
+
 	PrimaryController string
 	MultiControllers  av.SplitConfiguration
 	UserTCP           string
@@ -117,9 +129,15 @@ func newState(config NewSimConfiguration, startTime time.Time, manifest *VideoMa
 		VFRRunways: make(map[string]av.Runway),
 
 		Controllers:       make(map[string]*av.Controller),
+		ControlPositions:  config.ControlPositions,
 		PrimaryController: config.PrimaryController,
 		MultiControllers:  config.MultiControllers,
 		UserTCP:           serverCallsign,
+
+		SoloControllerConfig:  config.SoloControllerConfig,
+		MultiControllerConfig: config.MultiControllerConfig,
+		VirtualPositionConfig: config.VirtualPositionConfig,
+		FixPairAssignments:    config.FixPairAssignments,
 
 		DepartureRunways: config.DepartureRunways,
 		ArrivalRunways:   config.ArrivalRunways,
@@ -145,6 +163,9 @@ func newState(config NewSimConfiguration, startTime time.Time, manifest *VideoMa
 
 		Instructors: make(map[string]bool),
 	}
+
+	ss.virtualConsolidation = buildVirtualConsolidation(ss.VirtualPositionConfig)
+	ss.initializeControllerConfigurations(config.IsLocal)
 
 	// Grab initial METAR for each airport
 	for ap, m := range metar {
@@ -235,6 +256,92 @@ func newState(config NewSimConfiguration, startTime time.Time, manifest *VideoMa
 	}
 
 	return ss
+}
+
+func buildConsolidationLookup(cfg *ControllerConfiguration) map[string]string {
+	lookup := make(map[string]string)
+	if cfg == nil {
+		return lookup
+	}
+
+	for owner, pos := range cfg.Positions {
+		lookup[owner] = owner
+		for _, consolidated := range pos.ConsolidatedPositions {
+			if consolidated == "" {
+				continue
+			}
+			lookup[consolidated] = owner
+		}
+	}
+
+	return lookup
+}
+
+func buildVirtualConsolidation(cfg map[string]ControllerPositionConfig) map[string]string {
+	lookup := make(map[string]string)
+	for owner, pos := range cfg {
+		lookup[owner] = owner
+		for _, consolidated := range pos.ConsolidatedPositions {
+			if consolidated == "" {
+				continue
+			}
+			lookup[consolidated] = owner
+		}
+	}
+	return lookup
+}
+
+func (ss *State) initializeControllerConfigurations(isLocal bool) {
+	if isLocal || ss.MultiControllerConfig == nil {
+		ss.setActiveControllerConfiguration(ss.SoloControllerConfig)
+	} else {
+		ss.setActiveControllerConfiguration(ss.MultiControllerConfig)
+	}
+}
+
+func (ss *State) setActiveControllerConfiguration(cfg *ControllerConfiguration) {
+	ss.activeControllerConfig = cfg
+	ss.consolidationLookup = buildConsolidationLookup(cfg)
+	if cfg != nil {
+		ss.activeConfigurationID = strings.ToUpper(cfg.ConfigurationID)
+	} else {
+		ss.activeConfigurationID = ""
+	}
+}
+
+func (ss *State) resolveConsolidation(tcp string) string {
+	if tcp == "" {
+		return tcp
+	}
+	if owner, ok := ss.consolidationLookup[tcp]; ok {
+		return owner
+	}
+	if owner, ok := ss.virtualConsolidation[tcp]; ok {
+		return owner
+	}
+	return tcp
+}
+
+func (ss *State) ResolveFixPairOwner(flightType, entryFix, exitFix string) string {
+	if ss.activeConfigurationID == "" {
+		return ss.PrimaryController
+	}
+
+	entryFix = strings.ToUpper(strings.TrimSpace(entryFix))
+	exitFix = strings.ToUpper(strings.TrimSpace(exitFix))
+	flightType = strings.ToUpper(strings.TrimSpace(flightType))
+
+	assignments := ss.FixPairAssignments[ss.activeConfigurationID]
+	if len(assignments) == 0 {
+		return ss.PrimaryController
+	}
+
+	key := FixPairKey{FlightType: flightType, EntryFix: entryFix, ExitFix: exitFix}
+	if owner, ok := assignments[key]; ok && owner != "" {
+		return ss.resolveConsolidation(owner)
+	}
+
+	return ss.PrimaryController
 }
 
 func (ss *State) GetStateForController(tcp string) *State {
@@ -344,7 +451,7 @@ func (ss *State) GetRegularReleaseDepartures() []ReleaseDeparture {
 			}
 
 			for _, cl := range ss.FacilityAdaptation.CoordinationLists {
-				if slices.Contains(cl.Airports, dep.DepartureAirport) {
+				if slices.Contains(cl.Positions, dep.DepartureController) {
 					// It'll be in a STARS coordination list
 					return false
 				}
@@ -357,7 +464,7 @@ func (ss *State) GetSTARSReleaseDepartures() []ReleaseDeparture {
 	return util.FilterSlice(ss.ReleaseDepartures,
 		func(dep ReleaseDeparture) bool {
 			for _, cl := range ss.FacilityAdaptation.CoordinationLists {
-				if slices.Contains(cl.Airports, dep.DepartureAirport) {
+				if slices.Contains(cl.Positions, dep.DepartureController) {
 					return true
 				}
 			}

--- a/stars/commands.go
+++ b/stars/commands.go
@@ -2881,7 +2881,7 @@ func (sp *STARSPane) autoReleaseDepartures(ctx *panes.Context) {
 		// Get the aircraft that should be included in this list.
 		deps := util.FilterSlice(releaseAircraft,
 			func(dep sim.ReleaseDeparture) bool {
-				return slices.Contains(list.Airports, dep.DepartureAirport)
+				return slices.Contains(list.Positions, dep.DepartureController)
 			})
 
 		cl, ok := ps.CoordinationLists[list.Id]

--- a/stars/lists.go
+++ b/stars/lists.go
@@ -1140,7 +1140,7 @@ func (sp *STARSPane) drawCoordinationLists(ctx *panes.Context, paneExtent math.E
 					return false
 				}
 
-				if !slices.Contains(cl.Airports, dep.DepartureAirport) {
+				if !slices.Contains(cl.Positions, dep.DepartureController) {
 					return false
 				}
 				for callsign, state := range sp.TrackState {

--- a/stars/ui.go
+++ b/stars/ui.go
@@ -383,7 +383,7 @@ func (sp *STARSPane) DrawInfo(c *client.ControlClient, p platform.Platform, lg *
 		if imgui.BeginTableV("tclists", 3, tableFlags, imgui.Vec2{}, 0) {
 			imgui.TableSetupColumn("Id")
 			imgui.TableSetupColumn("Type")
-			imgui.TableSetupColumn("Airports")
+			imgui.TableSetupColumn("Positions")
 			imgui.TableHeadersRow()
 
 			for i, ap := range c.TowerListAirports() {
@@ -406,7 +406,7 @@ func (sp *STARSPane) DrawInfo(c *client.ControlClient, p platform.Platform, lg *
 				imgui.TableNextColumn()
 				imgui.Text("Coord. (" + list.Name + ")")
 				imgui.TableNextColumn()
-				imgui.Text(strings.Join(list.Airports, ", "))
+				imgui.Text(strings.Join(list.Positions, ", "))
 			}
 			imgui.EndTable()
 		}


### PR DESCRIPTION
## Summary
- add support for solo/multi/virtual controller configurations with fix-pair ownership across the simulation state
- require entry/exit fixes when loading arrivals and overflights and update the PVD scenario example to the new schema
- switch coordination list logic to be keyed by control positions instead of airports

## Testing
- go test ./... *(hangs; interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691167655c508326b58d89f7666f10f1)